### PR TITLE
bug fixing

### DIFF
--- a/RSS-Client/src/client/SocketListener.java
+++ b/RSS-Client/src/client/SocketListener.java
@@ -22,6 +22,8 @@ public class SocketListener extends Thread {
 		inputBuffer =new byte[BUFF_SIZE];
 		localPort = inLocalPort;
 		destPort = inDestPort;
+		try { socket = new DatagramSocket(localPort); }
+		catch (SocketException e) { e.printStackTrace(); System.out.println("SocketException while declaring datagram socket"); }
 		try {
 			if(inServerIP.equals("localhost")) serverIP = InetAddress.getLocalHost();
 			else serverIP = InetAddress.getByName(inServerIP);
@@ -29,9 +31,6 @@ public class SocketListener extends Thread {
 	}
 	
 	public void run() {
-		
-		try { socket = new DatagramSocket(localPort); }
-		catch (SocketException e) { e.printStackTrace(); System.out.println("SocketException while declaring datagram socket"); }
     	
     	while(true) {	//loop for receiving/parsing/handling incoming data
     		
@@ -48,7 +47,7 @@ public class SocketListener extends Thread {
     	    switch(inputBuffer[0]) {
 	    	
     	    case 0:	// a test case, print message to console
-    	    	app.display("data recieved, from server: " + data(inputBuffer));	//convert data to string, then send to app for displaying
+    	    	app.display("data recieved, from server: " + parseString(inputBuffer, 1));	//convert data to string, then send to app for displaying
     	    	break;
     	    	
     	    default:
@@ -79,17 +78,13 @@ public class SocketListener extends Thread {
 	}
 	
 	 
-    String data(byte[] a) { 	//function to convert byte array to string
+	String parseString(byte[] data, int start) { 	//function to convert byte array to string
     	
-        if (a == null) return null; 
+        if (data == null) return null; 
         String out = new String(); 
-        for(int i=0; a[i]!=0; i++)
-        	out += ((char) a[i]); 
+        for(int i=start; data[i]!=0; i++)
+        	out += ((char) data[i]); 
         return out; 
-    }
-    
-    protected void finalize() {
-		socket.close();
     }
 	
 	

--- a/Register-Share-System/src/Server/UDPServer.java
+++ b/Register-Share-System/src/Server/UDPServer.java
@@ -27,6 +27,11 @@ public class UDPServer extends Thread {											//internal server class
     	inputBuffer = new byte[BUFF_SIZE];
     	localPort = inLocalPort;
     	destPort = inDestPort; 
+    	try { serverSocket = new DatagramSocket(localPort); }	//create datagram socket and bind to port
+		catch (SocketException e) { 
+			e.printStackTrace(); 
+			System.out.println("socketException while creating DatagramSocket");
+		}
     	
     }
     
@@ -34,12 +39,7 @@ public class UDPServer extends Thread {											//internal server class
     	
     	System.out.println("starting UDP server");
     	
-    	try { serverSocket = new DatagramSocket(localPort); }	//create datagram socket and bind to port
-		catch (SocketException e) { 
-			e.printStackTrace(); 
-			System.out.println("socketException while creating DatagramSocket");
-			return;
-		}
+    	
 		
     	while(true) {	//loop for receiving/parsing/handling incoming data
 	     	
@@ -84,7 +84,13 @@ public class UDPServer extends Thread {											//internal server class
     
 public void sendString(String message, int op, InetAddress ip) {
 		
-		outputBuffer = message.getBytes(); 	//convert string to byte array
+		//convert string to byte array
+		byte[] tmpBuff = message.getBytes();		//get message as a byte array
+		outputBuffer = new byte[tmpBuff.length+1];
+		outputBuffer[0] = (byte) op;				//append a zero to beginning for server side command handler
+		for(int i=0; i<tmpBuff.length; i++)			//copy message byte array to output buffer
+		outputBuffer[i+1] = tmpBuff[i];
+		
     	dpSend = new DatagramPacket(outputBuffer, outputBuffer.length, ip, destPort); 	//create datagram packet 
 
     	try { serverSocket.send(dpSend); }	//send data


### PR DESCRIPTION
moved socket declaration back to server thread constructor
	-this will cause a problem if binding socket to port fails,
	since thread will start anyway even though socket is a null pointer
fixed the bug we saw last meeting where rather then printing response,
client printed "invalid operation recieved, initial byte out of range"